### PR TITLE
adds gradle build flag to prevent disabling app bundle generated apks…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,8 @@ android.useAndroidX=true
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+# Prevents app bundles from generated APKs with uncompressed libraries in the
+# APK itself, which results in the system NOT copying native libs to the native
+# lib directory, which is behavior the application relies on to find libstockfish.so
+# and associated .so files.
+android.bundle.enableUncompressedNativeLibs = false


### PR DESCRIPTION
… from copying native libs to the native lib folder of the application, so they are accessible in standard directories.